### PR TITLE
V1.4.4-RC2 Major overhaul of the RAT cookie handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MODNAME		:= github.com/wneessen/sotbot
 SPACE		:= $(null) $(null)
-CURVER		:= 1.4.4-RC1
+CURVER		:= 1.4.4-RC2
 CURARCH		:= $(shell uname -m | tr 'A-Z' 'a-z')
 CUROS		:= $(shell uname -s | tr 'A-Z' 'a-z')
 CURBRANCH	:= $(shell git branch | grep '*' | awk '{print $$2}')

--- a/api/api_time_rfc3339.go
+++ b/api/api_time_rfc3339.go
@@ -6,10 +6,10 @@ import (
 	"time"
 )
 
-type TimeRFC3339 time.Time
+type ApiTimeRFC3339 time.Time
 
 // UnmarshalJSON function for strings that are in RFC3339 format
-func (t *TimeRFC3339) UnmarshalJSON(s []byte) error {
+func (t *ApiTimeRFC3339) UnmarshalJSON(s []byte) error {
 	dateString := string(s)
 	dateString = strings.ReplaceAll(dateString, `"`, "")
 	if dateString == "null" {
@@ -24,6 +24,6 @@ func (t *TimeRFC3339) UnmarshalJSON(s []byte) error {
 	return nil
 }
 
-func (t TimeRFC3339) Time() time.Time {
+func (t ApiTimeRFC3339) Time() time.Time {
 	return time.Time(t)
 }

--- a/api/sot_dailydeed.go
+++ b/api/sot_dailydeed.go
@@ -27,15 +27,15 @@ type EventDataComponentData struct {
 }
 
 type BountyList struct {
-	Type                      string       `json:"#Type"`
-	Title                     string       `json:"Title"`
-	BodyText                  string       `json:"BodyText"`
-	StartDate                 TimeRFC3339  `json:"StartDate"`
-	EndDate                   TimeRFC3339  `json:"EndDate"`
-	CompletedAt               TimeRFC3339  `json:"CompletedAt"`
-	Image                     DailyDeedImg `json:"Image"`
-	EntitlementRewardValue    int          `json:"EntitlementRewardValue"`
-	EntitlementRewardCurrency string       `json:"EntitlementRewardCurrency"`
+	Type                      string         `json:"#Type"`
+	Title                     string         `json:"Title"`
+	BodyText                  string         `json:"BodyText"`
+	StartDate                 ApiTimeRFC3339 `json:"StartDate"`
+	EndDate                   ApiTimeRFC3339 `json:"EndDate"`
+	CompletedAt               ApiTimeRFC3339 `json:"CompletedAt"`
+	Image                     DailyDeedImg   `json:"Image"`
+	EntitlementRewardValue    int            `json:"EntitlementRewardValue"`
+	EntitlementRewardCurrency string         `json:"EntitlementRewardCurrency"`
 }
 
 type DailyDeedImg struct {

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -151,8 +151,8 @@ func (b *Bot) Run() {
 	signal.Notify(sc)
 
 	// We want timed events as well
-	aliveTimer := time.NewTicker(1 * time.Hour)
-	defer aliveTimer.Stop()
+	checkAuthTimer := time.NewTicker(time.Hour)
+	defer checkAuthTimer.Stop()
 
 	// Wait here until CTRL-C or other term signal is received.
 	l.Infof("Bot is ready and connected. Press CTRL-C to exit.")
@@ -172,8 +172,8 @@ func (b *Bot) Run() {
 
 				os.Exit(0)
 			}
-		case curTick := <-aliveTimer.C:
-			l.Infof("I am still alive. The time is %v", curTick.Format("2006-01-02 15:04:05"))
+		case <-checkAuthTimer.C:
+			go b.CheckSotAuth()
 		}
 	}
 }

--- a/bot/command_handler.go
+++ b/bot/command_handler.go
@@ -93,7 +93,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	case command == "!help" && cmdNum == 1:
 		re := handler.Help()
 		for _, msgText := range re {
-			response.DmUser(s, &userObj, "`"+msgText+"`", false, true)
+			response.DmUser(s, userObj, "`"+msgText+"`", false, true)
 		}
 		return
 
@@ -215,13 +215,13 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		if !userObj.HasRatCookie() {
 			return
 		}
-		re, err := handler.GetSotBalance(b.Db, b.HttpClient, &userObj)
+		re, err := handler.GetSotBalance(b.Db, b.HttpClient, userObj)
 		if err != nil {
 			if err.Error() == "notify" {
 				dmMsg := fmt.Sprintf("The last 3 attempts to communicate with the SoT API failed. " +
 					"This likely means, that your RAT cookie has expired. Please use the !setrat function to " +
 					"update your cookie.")
-				response.DmUser(s, &userObj, dmMsg, true, false)
+				response.DmUser(s, userObj, dmMsg, true, false)
 			} else {
 				re = fmt.Sprintf("An error occured checking your SoT balance: %v", err)
 				response.AnswerUser(s, m, re, true)
@@ -239,7 +239,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		if !userObj.HasRatCookie() {
 			return
 		}
-		re, err := handler.GetSotSeasonProgress(b.HttpClient, &userObj)
+		re, err := handler.GetSotSeasonProgress(b.HttpClient, userObj)
 		if err != nil {
 			re = fmt.Sprintf("An error occured checking your SoT season progress: %v", err)
 			response.AnswerUser(s, m, re, true)
@@ -256,7 +256,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		if !userObj.HasRatCookie() {
 			return
 		}
-		re, err := handler.GetSotReputation(b.HttpClient, &userObj, msgArray[1])
+		re, err := handler.GetSotReputation(b.HttpClient, userObj, msgArray[1])
 		if err != nil {
 			re = fmt.Sprintf("An error occured checking your SoT reputation level: %v", err)
 			response.AnswerUser(s, m, re, true)
@@ -273,7 +273,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		if !userObj.HasRatCookie() {
 			return
 		}
-		re, err := handler.GetSotLedger(b.HttpClient, &userObj, msgArray[1])
+		re, err := handler.GetSotLedger(b.HttpClient, userObj, msgArray[1])
 		if err != nil {
 			re = fmt.Sprintf("An error occured checking your SoT ledger rank: %v", err)
 			response.AnswerUser(s, m, re, true)
@@ -290,7 +290,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		if !userObj.HasRatCookie() {
 			return
 		}
-		re, err := handler.GetSotStats(b.HttpClient, &userObj)
+		re, err := handler.GetSotStats(b.HttpClient, userObj)
 		if err != nil {
 			re = fmt.Sprintf("An error occured checking your SoT general stats: %v", err)
 			response.AnswerUser(s, m, re, true)
@@ -307,7 +307,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		if !userObj.HasRatCookie() {
 			return
 		}
-		em, err := handler.GetDailyDeed(b.HttpClient, &userObj)
+		em, err := handler.GetDailyDeed(b.HttpClient, userObj)
 		if err != nil {
 			re := fmt.Sprintf("An error occured fetching the daily deed: %v", err)
 			response.AnswerUser(s, m, re, true)
@@ -324,7 +324,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		if !userObj.HasRatCookie() {
 			return
 		}
-		em, err := handler.GetSotAchievement(b.HttpClient, &userObj)
+		em, err := handler.GetSotAchievement(b.HttpClient, userObj)
 		if err != nil {
 			re := fmt.Sprintf("An error occured checking your SoT latest achievement: %v", err)
 			response.AnswerUser(s, m, re, true)
@@ -351,7 +351,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 			response.AnswerUser(s, m, re, true)
 			return
 		}
-		re, err := handler.UserSetRatCookie(b.Db, &userObj, msgArray[1])
+		re, err := handler.UserSetRatCookie(b.Db, userObj, msgArray[1])
 		if err != nil {
 			re := fmt.Sprintf("An error occured setting/updating your RAT cookie: %v", err)
 			response.AnswerUser(s, m, re, true)
@@ -362,7 +362,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// User management: Tell the user if they are registered
 	case (command == "!userinfo" || command == "!info") && cmdNum == 1:
-		re := handler.UserIsRegistered(&userObj)
+		re := handler.UserIsRegistered(userObj)
 		response.AnswerUser(s, m, re, true)
 		return
 

--- a/bot/playsot_handler.go
+++ b/bot/playsot_handler.go
@@ -45,7 +45,7 @@ func (b *Bot) UserPlaysSot(s *discordgo.Session, m *discordgo.PresenceUpdate) {
 						dmMsg := fmt.Sprintf("The last 3 attempts to communicate with the SoT API failed. " +
 							"This likely means, that your RAT cookie has expired. Please use the !setrat function to " +
 							"update your cookie.")
-						response.DmUser(s, &userObj, dmMsg, true, false)
+						response.DmUser(s, userObj, dmMsg, true, false)
 					}
 				}
 
@@ -68,7 +68,7 @@ func (b *Bot) UserPlaysSot(s *discordgo.Session, m *discordgo.PresenceUpdate) {
 					dmMsg := fmt.Sprintf("The last 3 attempts to communicate with the SoT API failed. " +
 						"This likely means, that your RAT cookie has expired. Please use the !setrat function to " +
 						"update your cookie.")
-					response.DmUser(s, &userObj, dmMsg, true, false)
+					response.DmUser(s, userObj, dmMsg, true, false)
 				}
 			}
 
@@ -86,7 +86,7 @@ func (b *Bot) UserPlaysSot(s *discordgo.Session, m *discordgo.PresenceUpdate) {
 				dmText := fmt.Sprintf("you played SoT recently. Your new balance is: %v gold, %v "+
 					"doubloons and %v ancient coins", p.Sprintf("%d", userBalance.Gold),
 					p.Sprintf("%d", userBalance.Doubloons), p.Sprintf("%d", userBalance.AncientCoins))
-				response.DmUser(s, &userObj, dmText, true, false)
+				response.DmUser(s, userObj, dmText, true, false)
 			}
 
 			if b.Config.GetBool("sot_play_announce") && b.AnnounceChan != nil {

--- a/bot/sot_checkauth.go
+++ b/bot/sot_checkauth.go
@@ -1,0 +1,53 @@
+package bot
+
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/wneessen/sotbot/database"
+	"github.com/wneessen/sotbot/random"
+	"github.com/wneessen/sotbot/response"
+	"github.com/wneessen/sotbot/user"
+	"time"
+)
+
+func (b *Bot) CheckSotAuth() {
+	l := log.WithFields(log.Fields{
+		"action": "bot.CheckSotAuth",
+	})
+
+	userList, err := database.GetUsers(b.Db)
+	if err != nil {
+		l.Errorf("Failed to fetch user list from DB: %v", err)
+		return
+	}
+	for _, curUser := range userList {
+		userObj, err := user.NewUser(b.Db, curUser.UserId)
+		if err != nil {
+			l.Errorf("Failed to create user object: %v", err)
+			break
+		}
+		if userObj.HasRatCookie() {
+			go func() {
+				randNum, err := random.Number(600)
+				if err != nil {
+					l.Errorf("Failed to generate random number: %v", err)
+					return
+				}
+				sleepTime, err := time.ParseDuration(fmt.Sprintf("%ds", randNum))
+				if err != nil {
+					l.Errorf("Failed to parse random number as duration: %v", err)
+					return
+				}
+				time.Sleep(sleepTime)
+				needsNotify, err := userObj.CheckAuth(b.Db, b.HttpClient)
+				if needsNotify {
+					userObj.RatCookie = ""
+					dmMsg := fmt.Sprintf("The last 3 attempts to communicate with the SoT API failed. " +
+						"This likely means, that your RAT cookie has expired. Please use the !setrat function to " +
+						"update your cookie.")
+					response.DmUser(b.Session, userObj, dmMsg, true, false)
+				}
+			}()
+		}
+	}
+}

--- a/bot/sot_checkauth.go
+++ b/bot/sot_checkauth.go
@@ -40,6 +40,10 @@ func (b *Bot) CheckSotAuth() {
 				}
 				time.Sleep(sleepTime)
 				needsNotify, err := userObj.CheckAuth(b.Db, b.HttpClient)
+				if err != nil {
+					l.Errorf("CheckAuth failed: %v", err)
+					return
+				}
 				if needsNotify {
 					userObj.RatCookie = ""
 					dmMsg := fmt.Sprintf("The last 3 attempts to communicate with the SoT API failed. " +

--- a/database/user.go
+++ b/database/user.go
@@ -21,7 +21,6 @@ func GetUser(d *gorm.DB, u string) (models.RegisteredUser, error) {
 	return userObj, nil
 }
 
-/*
 func GetUsers(d *gorm.DB) ([]models.RegisteredUser, error) {
 	userList := []models.RegisteredUser{}
 	dbTx := d.Find(&userList)
@@ -31,7 +30,6 @@ func GetUsers(d *gorm.DB) ([]models.RegisteredUser, error) {
 
 	return userList, nil
 }
-*/
 
 func CreateUser(d *gorm.DB, u string) error {
 	userObj := models.RegisteredUser{

--- a/handler/sot_ratcookie.go
+++ b/handler/sot_ratcookie.go
@@ -26,6 +26,7 @@ func UserSetRatCookie(d *gorm.DB, u *user.User, r string) (string, error) {
 		l.Errorf("Failed to delete 'failed_rat_tries' userpref in DB: %v", err)
 	}
 
+	u.RatCookie = r
 	responseMsg := "Thanks for setting/updating your RAT cookie."
 	return responseMsg, nil
 }

--- a/user/user.go
+++ b/user/user.go
@@ -17,14 +17,14 @@ type User struct {
 	UserInfo       *models.RegisteredUser
 }
 
-func NewUser(d *gorm.DB, i string) (User, error) {
+func NewUser(d *gorm.DB, i string) (*User, error) {
 	l := log.WithFields(log.Fields{
 		"action": "user.NewUser",
 	})
 	dbUser, err := database.GetUser(d, i)
 	if err != nil {
 		l.Errorf("Database user lookup failed: %v", err)
-		return User{}, err
+		return &User{}, err
 	}
 
 	userObj := User{AuthorId: i, UserInfo: &dbUser}
@@ -34,7 +34,7 @@ func NewUser(d *gorm.DB, i string) (User, error) {
 		userObj.RatCookie = userRatCookie
 	}
 
-	return userObj, nil
+	return &userObj, nil
 }
 
 func (u *User) IsRegistered() bool {


### PR DESCRIPTION
The check and notify user if RAT cookie failed logic has been removed from the updateBalance()
method. Instead there is a hourly job (with a random up to 10 minute delay) that will check the
validity of the RAT cookie. If it fails 4 times in a row with a HTTP 403, it is likely that the
cookie is expired or invalid. In this case, a notification DM is sent to the user.
