### PR TITLE
v1.4.5-RC2: Add trading routes caching (issue #34)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MODNAME		:= github.com/wneessen/sotbot
 SPACE		:= $(null) $(null)
-CURVER		:= 1.4.5-RC1
+CURVER		:= 1.4.5-RC2
 CURARCH		:= $(shell uname -m | tr 'A-Z' 'a-z')
 CUROS		:= $(shell uname -s | tr 'A-Z' 'a-z')
 CURBRANCH	:= $(shell git branch | grep '*' | awk '{print $$2}')

--- a/bot/command_handler.go
+++ b/bot/command_handler.go
@@ -382,7 +382,7 @@ func (b *Bot) CommandHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// RareThief: Get Traderoutes
 	case command == "!tr" && cmdNum == 1:
-		em, err := handler.GetTraderoutes(b.HttpClient)
+		em, err := handler.GetTraderoutes(b.HttpClient, b.Db)
 		if err != nil {
 			re := fmt.Sprintf("An error occurred fetching traderoutes: %v", err)
 			response.AnswerUser(s, m, re, true)

--- a/cache/readwrite.go
+++ b/cache/readwrite.go
@@ -1,0 +1,31 @@
+package cache
+
+import (
+	"fmt"
+	"github.com/wneessen/sotbot/database"
+	"gorm.io/gorm"
+)
+
+func Store(k string, o interface{}, d *gorm.DB) error {
+	objString, err := SerializeObj(o)
+	if err != nil {
+		return err
+	}
+	if err := database.StoreBotCache(d, k, objString); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Read(k string, o interface{}, d *gorm.DB) error {
+	objString := database.ReadBotCache(d, k)
+	if objString == "" {
+		return fmt.Errorf("Object not found in bot cache")
+	}
+	if err := DeserializeObj(objString, o); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cache/serialize.go
+++ b/cache/serialize.go
@@ -1,0 +1,33 @@
+package cache
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/gob"
+)
+
+func SerializeObj(o interface{}) (string, error) {
+	var serializeString bytes.Buffer
+	gobEnc := gob.NewEncoder(&serializeString)
+	if err := gobEnc.Encode(o); err != nil {
+		return "", err
+	}
+	serializeBase64 := base64.StdEncoding.EncodeToString(serializeString.Bytes())
+
+	return serializeBase64, nil
+}
+
+func DeserializeObj(s string, o interface{}) error {
+	var objBuffer bytes.Buffer
+	objString, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	objBuffer.Write(objString)
+	gobDec := gob.NewDecoder(&objBuffer)
+	if err := gobDec.Decode(o); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/database/cache.go
+++ b/database/cache.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"github.com/wneessen/sotbot/database/models"
+	"gorm.io/gorm"
+)
+
+func StoreBotCache(d *gorm.DB, k, v string) error {
+	botCache := models.BotCache{}
+	d.Where(models.BotCache{
+		Key: k,
+	}).First(&botCache)
+
+	if botCache.ID <= 0 {
+		dbTx := d.Create(&models.BotCache{
+			Key:   k,
+			Value: v,
+		})
+		if dbTx.Error != nil {
+			return dbTx.Error
+		}
+		return nil
+	}
+	botCache.Value = v
+	dbTx := d.Save(&botCache)
+	if dbTx.Error != nil {
+		return dbTx.Error
+	}
+	return nil
+}
+
+func ReadBotCache(d *gorm.DB, k string) string {
+	botCache := models.BotCache{}
+	d.Where(models.BotCache{
+		Key: k,
+	}).First(&botCache)
+
+	return botCache.Value
+}

--- a/database/init.go
+++ b/database/init.go
@@ -26,6 +26,7 @@ func ConnectDB(d, ll string) (*gorm.DB, error) {
 	}
 
 	if err := db.AutoMigrate(
+		&models.BotCache{},
 		&models.RegisteredUser{},
 		&models.UserPref{},
 		&models.SotBalance{},

--- a/database/models/bot_cache.go
+++ b/database/models/bot_cache.go
@@ -1,0 +1,7 @@
+package models
+
+type BotCache struct {
+	General
+	Key   string `gorm:"index:idx_cache_key"`
+	Value string `gorm:"size:8196"`
+}

--- a/handler/rt_traderoutes.go
+++ b/handler/rt_traderoutes.go
@@ -2,22 +2,46 @@ package handler
 
 import (
 	"fmt"
+	"github.com/wneessen/sotbot/cache"
+	"gorm.io/gorm"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	log "github.com/sirupsen/logrus"
 	"github.com/wneessen/sotbot/api"
 )
 
-func GetTraderoutes(hc *http.Client) (*discordgo.MessageEmbed, error) {
+func GetTraderoutes(hc *http.Client, d *gorm.DB) (*discordgo.MessageEmbed, error) {
 	l := log.WithFields(log.Fields{
 		"action": "handler.GetTraderoutes",
 	})
-	traderoutes, err := api.GetTraderoutes(hc)
-	if err != nil {
-		l.Errorf("An error occurred fetching traderoutes: %v", err)
-		return &discordgo.MessageEmbed{}, err
+
+	var traderoutes api.Traderoutes
+	var err error
+	fromCache := true
+	if err := cache.Read("traderoutes", &traderoutes, d); err != nil {
+		l.Errorf("Failed to read traderoutes from DB cache: %v", err)
+		fromCache = false
+	}
+
+	if fromCache {
+		if traderoutes.ValidThru.Unix() < time.Now().Unix() {
+			fromCache = false
+		}
+		l.Debugf("Cache traderoutes still valid. Using cached version")
+	}
+
+	if !fromCache {
+		traderoutes, err = api.GetTraderoutes(hc)
+		if err != nil {
+			l.Errorf("An error occurred fetching traderoutes: %v", err)
+			return &discordgo.MessageEmbed{}, err
+		}
+		if err := cache.Store("traderoutes", traderoutes, d); err != nil {
+			l.Errorf("Failed to store traderoutes in DB cache: %v", err)
+		}
 	}
 
 	var respondOutposts []*discordgo.MessageEmbedField


### PR DESCRIPTION
Since the trading routes API seems to be not stable, a local cache for the TRs has been
introduced. To be future-proof a "bot cache" has been added. This is a general cache that
the bot can use to easily serialize objects and store them as base64 encoded string in the
DB for later use. Since the playsot_handler.go makes use of serialization as well, it's
code has been adjusted to make use of the new cache methods as well. To decide if the
TRs are still valid, the TR dates are now parsed and stored as "ValidFrom" and "ValidThru"
fields in the TR struct