### PR TITLE
#49 better activity handling for the SoT auto-tracking feature

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -42,11 +42,13 @@ func NewUser(d *gorm.DB, c *viper.Viper, i string) (*User, error) {
 		userObj.RatCookie = userRatCookie
 
 		userRatCookieExpireString := database.UserGetPrefEncString(d, c, dbUser.ID, "rat_cookie_expire")
-		userRatCookieExpireInt, err := strconv.ParseInt(userRatCookieExpireString, 10, 64)
-		if err != nil {
-			l.Errorf("Failed to convert string to int64: %v", err)
+		if userRatCookieExpireString != "" {
+			userRatCookieExpireInt, err := strconv.ParseInt(userRatCookieExpireString, 10, 64)
+			if err != nil {
+				l.Errorf("Failed to convert string to int64: %v", err)
+			}
+			userObj.RatExpire = time.Unix(userRatCookieExpireInt, 0)
 		}
-		userObj.RatExpire = time.Unix(userRatCookieExpireInt, 0)
 	}
 
 	return &userObj, nil


### PR DESCRIPTION
Before the bot checked if the "Activities" array is empty or not. If not, it would not register that a user stopped playing. This causes issues if more than one instance of Discord is running, each with a different activity. Once the user stopped playing SoT the old status would show up again and the bot wouldn't register this.

Now there is a simple "In the activities array there is SoT or not" check, that should address the afore mentioned issue.