### PR TITLE
v1.4.7-DEV: The fix for #49 introduced a race condition

### DIFF
--- a/bot/playsot_handler.go
+++ b/bot/playsot_handler.go
@@ -53,6 +53,10 @@ func (b *Bot) UserPlaysSot(s *discordgo.Session, m *discordgo.PresenceUpdate) {
 	}
 
 	if playingSot && userObj.RatIsValid() {
+		userIsPlaying := database.UserGetPrefString(b.Db, userObj.UserInfo.ID, "playing_sot")
+		if userIsPlaying != "" {
+			return
+		}
 		l.Debugf("%v started playing SoT. Updating balance...", discordUser.Username)
 		userBalance, err := api.GetBalance(b.HttpClient, userObj.RatCookie)
 		if err != nil {


### PR DESCRIPTION
In some cases, Steam (at least) seems to update the status twice, causing a race condition, so
that the bot won't notice that the user stopped playing.