### PR TITLE
v1.4.7-RC4: Regularly check if the RAT cookie is still valid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MODNAME		:= github.com/wneessen/sotbot
 SPACE		:= $(null) $(null)
-CURVER		:= 1.4.7-RC3
+CURVER		:= 1.4.7-RC4
 CURARCH		:= $(shell uname -m | tr 'A-Z' 'a-z')
 CUROS		:= $(shell uname -s | tr 'A-Z' 'a-z')
 BUILDARCH	:= $(CUROS)_$(CURARCH)

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -240,6 +240,7 @@ func (b *Bot) Run() {
 			}
 		case <-summaryTimer.C:
 			go b.CollectSummaryData()
+			go b.CheckRatCookies()
 		}
 	}
 }

--- a/bot/sot_ratcookie_expire.go
+++ b/bot/sot_ratcookie_expire.go
@@ -1,0 +1,40 @@
+package bot
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/wneessen/sotbot/database"
+	"github.com/wneessen/sotbot/response"
+	"github.com/wneessen/sotbot/user"
+	"time"
+)
+
+func (b *Bot) CheckRatCookies() {
+	l := log.WithFields(log.Fields{
+		"action": "bot.CheckRatCookies",
+	})
+
+	userList, err := database.GetUsers(b.Db)
+	if err != nil {
+		l.Errorf("Failed to fetch user list from DB: %v", err)
+		return
+	}
+	for _, curUser := range userList {
+		userObj, err := user.NewUser(b.Db, b.Config, curUser.UserId)
+		if err != nil {
+			l.Errorf("Failed to create user object: %v", err)
+			continue
+		}
+		if userObj.HasRatCookie() && !userObj.RatIsValid() {
+			userNotified := database.UserGetPrefString(b.Db, userObj.UserInfo.ID, "rat_expire_notify")
+			if userNotified == "" {
+				dmMsg := "Your SoT RAT cookie has expired. Please use the `/setrat` command to set a new one."
+				response.DmUser(b.Session, userObj, dmMsg, true, false)
+				if err := database.UserSetPref(b.Db, userObj.UserInfo.ID, "rat_expire_notify",
+					time.Now().String()); err != nil {
+					l.Errorf("Failed to set 'rat_expire_notify' flag in database for user %q: %v",
+						userObj.UserInfo.UserId, err)
+				}
+			}
+		}
+	}
+}

--- a/handler/sot_ratcookie.go
+++ b/handler/sot_ratcookie.go
@@ -55,5 +55,9 @@ func UserSetRatCookie(d *gorm.DB, c *viper.Viper, u *user.User, r string) (strin
 
 	u.RatCookie = r
 	responseMsg := "Thanks for setting/updating your RAT cookie."
+	if err := database.UserDelPref(d, u.UserInfo.ID, "rat_expire_notify"); err != nil {
+		l.Errorf("Failed to delete 'rat_expire_notify' user preference for user %q: %v", u.UserInfo.UserId,
+			err)
+	}
 	return responseMsg, nil
 }


### PR DESCRIPTION
The bot will check every 30 mins. if the registered RAT cookie of a specific user is still valid.
Is the cookie expired, the bot will notify the user one via DM and set a state-flag in the database,
so it will not create multiple DMs every 30 mins. Is a new RAT cookie registered, the flag will be
deleted.