### PR TITLE
v1.4.8-DEV.1: Force summary collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MODNAME		:= github.com/wneessen/sotbot
 SPACE		:= $(null) $(null)
-CURVER		:= 1.4.7
+CURVER		:= 1.4.8-DEV.1
 CURARCH		:= $(shell uname -m | tr 'A-Z' 'a-z')
 CUROS		:= $(shell uname -s | tr 'A-Z' 'a-z')
 BUILDARCH	:= $(CUROS)_$(CURARCH)

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -239,7 +239,7 @@ func (b *Bot) Run() {
 				os.Exit(0)
 			}
 		case <-summaryTimer.C:
-			go b.CollectSummaryData()
+			go func() { _ = b.CollectSummaryData() }()
 			go b.CheckRatCookies()
 		}
 	}

--- a/bot/slashcmd_handler.go
+++ b/bot/slashcmd_handler.go
@@ -508,5 +508,31 @@ func (b *Bot) SlashCmdHandler(s *discordgo.Session, i *discordgo.InteractionCrea
 		}
 		response.SlashCmdResponseEdit(s, i.Interaction, userObj, re, true)
 		return
+
+	// SoT: Force summary data collection for a specific user
+	case cmdName == "collectsummary":
+		response.SlashCmdResponseDeferredEphemeral(s, i.Interaction)
+		if !userObj.IsRegistered() {
+			re := "Sorry, but you are not a registered user. Please contact a admin to get registered."
+			response.SlashCmdResponseEdit(s, i.Interaction, userObj, re, true)
+			return
+		}
+		if !userObj.HasRatCookie() {
+			re := "Sorry, but you seems to not have a RAT cookie registered with me. Please use `/setrat` to set one."
+			response.SlashCmdResponseEdit(s, i.Interaction, userObj, re, true)
+			return
+		}
+		if !userObj.RatIsValid() {
+			re := "Sorry, but it seems that your RAT cookie in my database has expired. Please update."
+			response.SlashCmdResponseEdit(s, i.Interaction, userObj, re, true)
+			return
+		}
+		if err := b.CollectSummaryData(userObj.UserInfo.UserId); err != nil {
+			re := fmt.Sprintf("An error occurred collecting your summary data: %v", err)
+			response.SlashCmdResponseEdit(s, i.Interaction, userObj, re, true)
+			return
+		}
+		response.SlashCmdResponseEdit(s, i.Interaction, userObj, "Collection completed", true)
+		return
 	}
 }

--- a/bot/slashcmd_list.go
+++ b/bot/slashcmd_list.go
@@ -249,6 +249,12 @@ func (b *Bot) SlashCmdList() []*discordgo.ApplicationCommand {
 			Name:        "summary",
 			Description: "Let SoTBot tell you your daily summary",
 		},
+
+		// SoT: Force summary data collection
+		{
+			Name:        "collectsummary",
+			Description: "Forces the SoTBot to collect the summary data for your user",
+		},
 	}
 
 	return slashCmds

--- a/bot/sot_collectsummarydata.go
+++ b/bot/sot_collectsummarydata.go
@@ -6,19 +6,35 @@ import (
 	"github.com/wneessen/sotbot/api"
 	"github.com/wneessen/sotbot/cache"
 	"github.com/wneessen/sotbot/database"
+	"github.com/wneessen/sotbot/database/models"
 	"github.com/wneessen/sotbot/user"
 	"time"
 )
 
-func (b *Bot) CollectSummaryData() {
+func (b *Bot) CollectSummaryData(userId ...string) error {
 	l := log.WithFields(log.Fields{
 		"action": "bot.CollectSummaryData",
 	})
 
-	userList, err := database.GetUsers(b.Db)
-	if err != nil {
-		l.Errorf("Failed to fetch user list from DB: %v", err)
-		return
+	var userList []models.RegisteredUser
+	forceCollection := false
+	if len(userId) == 1 {
+		userData, err := database.GetUser(b.Db, userId[0])
+		if err != nil {
+			l.Errorf("Failed to fetch user data from database: %s", err)
+			return fmt.Errorf("Failed to fetch user data from database: %s", err)
+		}
+		userList = append(userList, userData)
+		forceCollection = true
+		l.Debugf("UserID has been given. Forcing summary collection for user %s", userData.UserId)
+	}
+	if len(userId) != 1 {
+		var err error
+		userList, err = database.GetUsers(b.Db)
+		if err != nil {
+			l.Errorf("Failed to fetch user list from DB: %v", err)
+			return fmt.Errorf("Failed to fetch user list from DB: %s", err)
+		}
 	}
 	for _, curUser := range userList {
 		userObj, err := user.NewUser(b.Db, b.Config, curUser.UserId)
@@ -34,13 +50,13 @@ func (b *Bot) CollectSummaryData() {
 			l.Errorf("Failed to read last summary update time for user %v from cache. Assuming first ever run.",
 				userObj.UserInfo.UserId)
 		}
-		if time.Now().Unix()-lastCheck.Unix() < 86400 {
+		if time.Now().Unix()-lastCheck.Unix() < 86400 && !forceCollection {
 			l.Debugf("Last collection run for user %v was %v (less than 24h ago). Skipping for now.",
 				userObj.UserInfo.UserId, lastCheck.String())
 			continue
 		}
 
-		if userObj.HasRatCookie() {
+		if userObj.HasRatCookie() && userObj.RatIsValid() {
 			userBalance, err := api.GetBalance(b.HttpClient, userObj.RatCookie)
 			if err != nil {
 				l.Errorf("Failed to fetch user balance from API: %v", err)
@@ -62,8 +78,11 @@ func (b *Bot) CollectSummaryData() {
 			if err := cache.Store(updateKey, time.Now(), b.Db); err != nil {
 				l.Errorf("Failed to store/update collection time in DB")
 			}
+			continue
 		}
 		l.Errorf("User %v needs a summary update but seems to have no valid RAT cookie",
 			userObj.UserInfo.UserId)
 	}
+
+	return nil
 }


### PR DESCRIPTION
The summary collection is running every 24h. This can cause issues for users in different time
zones. To mitigate this, a `/collectsummary` command has been added, so that a user is able to
force a collection of the current summary data that will be used to compare with the next time
`/summary` is executed.